### PR TITLE
fix(angular): make package version detection more robust

### DIFF
--- a/angular/download.sh
+++ b/angular/download.sh
@@ -63,7 +63,7 @@ if [[ -z "${TOKEN_USER}" ]]; then
 fi
 
 # Determine the latest published version of the XLTS for AngularJS packages
-ANGULAR_VERSION="$(curl -f --silent "${REGISTRY}/@xlts.dev/${ANGULAR_PACKAGES[0]}" -H "Authorization: Bearer ${TOKEN}" | awk -F'"latest":' '{print $2}' | xargs)"
+ANGULAR_VERSION="$(curl -f --silent "${REGISTRY}/@xlts.dev/${ANGULAR_PACKAGES[0]}" -H "Authorization: Bearer ${TOKEN}" | awk -F'"latest":' '{print $2}' | cut -d'}' -f1 | cut -d',' -f1 | xargs)"
 if [[ -z "${ANGULAR_VERSION}" ]]; then
   echo "ERROR: Unable to determine the latest XLTS for AngularJS version" 1>&2
   exit 1


### PR DESCRIPTION
The command used to determine the latest AngularJS package version was assuming that the return JSON response was pretty-formatted (with one key-value pair per line). However, in recent versions of the registry, the JSON response is formatted without whitespace to reduce the response size.

Make the command more robust by ensuring it can handle the returned JSON response regardless of its formatting.